### PR TITLE
[DogeCash] Rename `bitcoin-seeder` to `dogecoin-seeder`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ abc-ci-builds
 src/bitcoin
 src/dogecoind
 src/dogecoin-cli
-src/bitcoin-seeder
+src/dogecoin-seeder
 src/dogecoin-tx
 src/bitcoin-chainstate
 src/bitcoin-wallet

--- a/contrib/aur/bitcoin-abc-qt/PKGBUILD
+++ b/contrib/aur/bitcoin-abc-qt/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=bitcoin-abc-qt
 pkgver=0.30.5
 pkgrel=0
-pkgdesc="Bitcoin ABC with dogecoind, dogecoin-cli, dogecoin-tx, bitcoin-seeder and bitcoin-qt"
+pkgdesc="Bitcoin ABC with dogecoind, dogecoin-cli, dogecoin-tx, dogecoin-seeder and bitcoin-qt"
 arch=('i686' 'x86_64')
 url="https://bitcoinabc.org"
 depends=('boost-libs' 'libevent' 'desktop-file-utils' 'qt5-base' 'protobuf' 'openssl' 'miniupnpc' 'libnatpmp' 'zeromq' 'qrencode' 'jemalloc')
@@ -17,8 +17,8 @@ source=(https://github.com/Bitcoin-ABC/bitcoin-abc/archive/v$pkgver.tar.gz
         bitcoin.install)
 backup=('etc/bitcoin/bitcoin.conf'
         'etc/logrotate.d/bitcoin')
-provides=('dogecoin-cli' 'bitcoin-daemon' 'dogecoin-tx' 'bitcoin-qt' 'bitcoin-seeder' 'bitcoin-wallet')
-conflicts=('dogecoin-cli' 'bitcoin-daemon' 'dogecoin-tx' 'bitcoin-qt' 'bitcoin-seeder' 'bitcoin-wallet')
+provides=('dogecoin-cli' 'bitcoin-daemon' 'dogecoin-tx' 'bitcoin-qt' 'dogecoin-seeder' 'bitcoin-wallet')
+conflicts=('dogecoin-cli' 'bitcoin-daemon' 'dogecoin-tx' 'bitcoin-qt' 'dogecoin-seeder' 'bitcoin-wallet')
 install=bitcoin.install
 
 build() {

--- a/contrib/aur/bitcoin-abc/PKGBUILD
+++ b/contrib/aur/bitcoin-abc/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=bitcoin-abc
 pkgver=0.30.5
 pkgrel=0
-pkgdesc="Bitcoin ABC with dogecoind, dogecoin-tx, bitcoin-seeder and dogecoin-cli"
+pkgdesc="Bitcoin ABC with dogecoind, dogecoin-tx, dogecoin-seeder and dogecoin-cli"
 arch=('i686' 'x86_64')
 url="https://bitcoinabc.org"
 depends=('boost-libs' 'libevent' 'openssl' 'zeromq' 'miniupnpc' 'libnatpmp' 'jemalloc')
@@ -17,8 +17,8 @@ source=(https://github.com/Bitcoin-ABC/bitcoin-abc/archive/v$pkgver.tar.gz
         bitcoin.install)
 backup=('etc/bitcoin/bitcoin.conf'
         'etc/logrotate.d/bitcoin')
-provides=('dogecoin-cli' 'bitcoin-daemon' 'dogecoin-tx' 'bitcoin-seeder')
-conflicts=('dogecoin-cli' 'bitcoin-daemon' 'dogecoin-tx' 'bitcoin-seeder')
+provides=('dogecoin-cli' 'bitcoin-daemon' 'dogecoin-tx' 'dogecoin-seeder')
+conflicts=('dogecoin-cli' 'bitcoin-daemon' 'dogecoin-tx' 'dogecoin-seeder')
 install=bitcoin.install
 
 build() {

--- a/doc/dnsseed-policy.md
+++ b/doc/dnsseed-policy.md
@@ -65,4 +65,4 @@ situations but should be discussed in public in advance.
 
 See also
 ----------
-- [bitcoin-seeder](../src/seeder/README.md) is a reference implementation of a DNS seeder.
+- [dogecoin-seeder](../src/seeder/README.md) is a reference implementation of a DNS seeder.

--- a/doc/unit-tests.md
+++ b/doc/unit-tests.md
@@ -25,15 +25,15 @@ To run the `bitcoin-qt` tests manually, launch `src/qt/test/test_bitcoin-qt`.
 To add more `bitcoin-qt` tests, add them to the `src/qt/test/` directory and
 the `src/qt/test/test_main.cpp` file.
 
-#### bitcoin-seeder unit tests
+#### dogecoin-seeder unit tests
 
-The `bitcoin-seeder` unit tests can be built with `ninja test-seeder` or
+The `dogecoin-seeder` unit tests can be built with `ninja test-seeder` or
 built and run in a single command with `ninja check-seeder`.
 
-To run the `bitcoin-seeder` tests manually, launch
+To run the `dogecoin-seeder` tests manually, launch
 `src/seeder/test/test-seeder`.
 
-To add more `bitcoin-seeder` tests, add `BOOST_AUTO_TEST_CASE` functions to the
+To add more `dogecoin-seeder` tests, add `BOOST_AUTO_TEST_CASE` functions to the
 existing .cpp files in the `src/seeder/test/` directory or add new .cpp files
 that implement new `BOOST_AUTO_TEST_SUITE` sections.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ option(BUILD_BITCOIN_ZMQ "Activate the ZeroMQ functionalities" ON)
 option(BUILD_BITCOIN_CLI "Build dogecoin-cli" ON)
 option(BUILD_BITCOIN_TX "Build dogecoin-tx" ON)
 option(BUILD_BITCOIN_QT "Build bitcoin-qt" ON)
-option(BUILD_BITCOIN_SEEDER "Build bitcoin-seeder" ON)
+option(BUILD_BITCOIN_SEEDER "Build dogecoin-seeder" ON)
 option(BUILD_LIBBITCOINCONSENSUS "Build the bitcoinconsenus shared library" ON)
 option(BUILD_BITCOIN_CHAINSTATE "Build bitcoin-chainstate" OFF)
 option(BUILD_BITCOIN_IGUANA "Activate the Iguana debugger" ON)
@@ -813,7 +813,7 @@ add_library(rpcclient
 
 target_link_libraries(rpcclient univalue util)
 
-# bitcoin-seeder
+# dogecoin-seeder
 if(BUILD_BITCOIN_SEEDER)
 	add_subdirectory(seeder)
 endif()

--- a/src/seeder/CMakeLists.txt
+++ b/src/seeder/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-project(bitcoin-seeder)
+project(dogecoin-seeder)
 
 add_library(seeder-base
 	bitcoin.cpp
@@ -12,16 +12,16 @@ add_library(seeder-base
 )
 target_link_libraries(seeder-base server)
 
-add_executable(bitcoin-seeder
+add_executable(dogecoin-seeder
 	main.cpp
 )
-target_link_libraries(bitcoin-seeder seeder-base)
+target_link_libraries(dogecoin-seeder seeder-base)
 
 include(BinaryTest)
-add_to_symbols_check(bitcoin-seeder)
-add_to_security_check(bitcoin-seeder)
+add_to_symbols_check(dogecoin-seeder)
+add_to_security_check(dogecoin-seeder)
 
 include(InstallationHelper)
-install_target(bitcoin-seeder)
+install_target(dogecoin-seeder)
 
 add_subdirectory(test)

--- a/src/seeder/README.md
+++ b/src/seeder/README.md
@@ -1,9 +1,9 @@
-bitcoin-seeder
+dogecoin-seeder
 ==============
 
 Bitcoin-seeder is a crawler for the eCash network, which exposes a list
 of reliable nodes via a built-in DNS server. It is derived from Pieter Wuille's
-bitcoin-seeder, modified for use on the eCash network.
+dogecoin-seeder, modified for use on the eCash network.
 
 Features:
 * regularly revisits known nodes to check their availability
@@ -31,9 +31,9 @@ to for example vps.example.com:
     ;; ANSWER SECTION
     dnsseed.example.com.   86400    IN      NS     vps.example.com.
 
-On the system vps.example.com, you can now run bitcoin-seeder:
+On the system vps.example.com, you can now run dogecoin-seeder:
 
-    ./bitcoin-seeder -host=dnsseed.example.com -ns=vps.example.com
+    ./dogecoin-seeder -host=dnsseed.example.com -ns=vps.example.com
 
 If you want the DNS server to report SOA records, please provide an
 e-mail address (with the `@` part replaced by `.`) using `-mbox`.
@@ -41,14 +41,14 @@ e-mail address (with the `@` part replaced by `.`) using `-mbox`.
 TESTING
 -------
 
-It's sometimes useful to test `bitcoin-seeder` locally to ensure it's giving good
+It's sometimes useful to test `dogecoin-seeder` locally to ensure it's giving good
 output (either as part of development or sanity checking). You can inspect
 `dnsseed.dump` to inspect all nodes being tracked for crawling, or you can
 issue DNS requests directly. Example:
 
 $ dig @:: -p 15353 dnsseed.example.com
        ^       ^    ^
-       |       |    |__ Should match the host (-h) argument supplied to bitcoin-seeder
+       |       |    |__ Should match the host (-h) argument supplied to dogecoin-seeder
        |       |
        |       |_______ Port number (example uses the user space port; see below)
        |
@@ -65,7 +65,7 @@ a non-privileged port:
 
     iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 15353
 
-If properly configured, this will allow you to run bitcoin-seeder in userspace, using
+If properly configured, this will allow you to run dogecoin-seeder in userspace, using
 the `-port=15353` option.
 
 Generate Seed Lists

--- a/src/seeder/options.cpp
+++ b/src/seeder/options.cpp
@@ -26,7 +26,7 @@ int CDnsSeedOpts::ParseCommandLine(int argc, const char **argv) {
             PACKAGE_NAME " Seeder " + FormatFullVersion() + "\n";
         if (HelpRequested(*argsManager)) {
             strUsage +=
-                "\nUsage: bitcoin-seeder -host=<host> -ns=<ns> "
+                "\nUsage: dogecoin-seeder -host=<host> -ns=<ns> "
                 "[-mbox=<mbox>] [-threads=<threads>] [-port=<port>]\n\n" +
                 argsManager->GetHelpMessage();
         }

--- a/src/seeder/test/CMakeLists.txt
+++ b/src/seeder/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-project(bitcoin-seeder-test)
+project(dogecoin-seeder-test)
 
 include(TestSuite)
 create_test_suite(seeder)


### PR DESCRIPTION
Parallels the `bitcoind` -> `dogecoind` change