### PR TITLE
[Dogecash] Replace Bitcoin -> Dogecoin in some places

### DIFF
--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -53,9 +53,9 @@ Var StartMenuGroup
 # Installer attributes
 OutFile "@CPACK_TOPLEVEL_DIRECTORY@/@CPACK_OUTPUT_FILE_NAME@"
 !if "@CPACK_SYSTEM_NAME@" == "x86_64-w64-mingw32"
-InstallDir $PROGRAMFILES64\Bitcoin-abc
+InstallDir $PROGRAMFILES64\Dogecash
 !else
-InstallDir $PROGRAMFILES\Bitcoin-abc
+InstallDir $PROGRAMFILES\Dogecash
 !endif
 CRCCheck on
 XPStyle on
@@ -108,7 +108,7 @@ Section -post SEC0001
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
     WriteRegStr HKCR "@CPACK_PACKAGE_NAME@" "URL Protocol" ""
-    WriteRegStr HKCR "@CPACK_PACKAGE_NAME@" "" "URL:Bitcoin-abc"
+    WriteRegStr HKCR "@CPACK_PACKAGE_NAME@" "" "URL:Dogecash"
     WriteRegStr HKCR "@CPACK_PACKAGE_NAME@\DefaultIcon" "" "$INSTDIR\${BITCOIN_GUI_NAME}"
     WriteRegStr HKCR "@CPACK_PACKAGE_NAME@\shell\open\command" "" '"$INSTDIR\${BITCOIN_GUI_NAME}" "%1"'
 SectionEnd
@@ -141,7 +141,7 @@ Section -un.post UNSEC0001
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\@CPACK_NSIS_DISPLAY_NAME@ (testnet).lnk"
-    Delete /REBOOTOK "$SMSTARTUP\Bitcoin-abc.lnk"
+    Delete /REBOOTOK "$SMSTARTUP\Dogecash.lnk"
     Delete /REBOOTOK "$INSTDIR\uninstall.exe"
     Delete /REBOOTOK "$INSTDIR\debug.log"
     Delete /REBOOTOK "$INSTDIR\db.log"

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -47,7 +47,7 @@ CTxDestination DecodeLegacyDestination(const std::string &str,
     if (!DecodeBase58Check(str, data, 21)) {
         return CNoDestination();
     }
-    // base58-encoded Bitcoin addresses.
+    // base58-encoded Dogecoin addresses.
     // Public-key-hash-addresses have version 0 (or 111 testnet).
     // The data vector contains RIPEMD160(SHA256(pubkey)), where pubkey is
     // the serialized public key.

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -105,7 +105,7 @@ AddressBookPage::AddressBookPage(const PlatformStyle *platformStyle, Mode _mode,
     switch (tab) {
         case SendingTab:
             ui->labelExplanation->setText(
-                tr("These are your Bitcoin addresses for sending payments. "
+                tr("These are your Dogecoin addresses for sending payments. "
                    "Always check the amount and the receiving address before "
                    "sending coins."));
             ui->deleteAddress->setVisible(true);
@@ -113,7 +113,7 @@ AddressBookPage::AddressBookPage(const PlatformStyle *platformStyle, Mode _mode,
             break;
         case ReceivingTab:
             ui->labelExplanation->setText(
-                tr("These are your Bitcoin addresses for receiving payments. "
+                tr("These are your Dogecoin addresses for receiving payments. "
                    "Use the 'Create new receiving address' button in the "
                    "receive tab to create new addresses."));
             ui->deleteAddress->setVisible(false);

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -31,7 +31,7 @@ public:
     enum ColumnIndex {
         /** User specified label */
         Label = 0,
-        /** Bitcoin address */
+        /** Dogecoin address */
         Address = 1
     };
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -259,7 +259,7 @@ void BitcoinGUI::createActions() {
 
     sendCoinsAction = new QAction(
         platformStyle->SingleColorIcon(":/icons/send"), tr("&Send"), this);
-    sendCoinsAction->setStatusTip(tr("Send coins to a Bitcoin address"));
+    sendCoinsAction->setStatusTip(tr("Send coins to a Dogecoin address"));
     sendCoinsAction->setToolTip(sendCoinsAction->statusTip());
     sendCoinsAction->setCheckable(true);
     sendCoinsAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_2));
@@ -355,7 +355,7 @@ void BitcoinGUI::createActions() {
         tr("Change the passphrase used for wallet encryption"));
     signMessageAction = new QAction(tr("Sign &message..."), this);
     signMessageAction->setStatusTip(
-        tr("Sign messages with your Bitcoin addresses to prove you own them"));
+        tr("Sign messages with your Dogecoin addresses to prove you own them"));
     verifyMessageAction = new QAction(tr("&Verify message..."), this);
     verifyMessageAction->setStatusTip(
         tr("Verify messages to ensure they were signed with specified Bitcoin "
@@ -1027,7 +1027,7 @@ void BitcoinGUI::updateNetworkState() {
     QString tooltip;
 
     if (m_node.getNetworkActive()) {
-        tooltip = tr("%n active connection(s) to Bitcoin network", "", count) +
+        tooltip = tr("%n active connection(s) to Dogecoin network", "", count) +
                   QString(".<br>") + tr("Click to disable network activity.");
     } else {
         tooltip = tr("Network activity disabled.") + QString("<br>") +

--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -98,7 +98,7 @@ void EditAddressDialog::accept() {
             case AddressTableModel::INVALID_ADDRESS:
                 QMessageBox::warning(this, windowTitle(),
                                      tr("The entered address \"%1\" is not a "
-                                        "valid Bitcoin address.")
+                                        "valid Dogecoin address.")
                                          .arg(ui->addressEdit->text()),
                                      QMessageBox::Ok, QMessageBox::Ok);
                 break;

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -282,7 +282,7 @@
        <item>
         <widget class="QCheckBox" name="connectSocks">
          <property name="toolTip">
-          <string>Connect to the Bitcoin network through a SOCKS5 proxy.</string>
+          <string>Connect to the Dogecoin network through a SOCKS5 proxy.</string>
          </property>
          <property name="text">
           <string>&amp;Connect through SOCKS5 proxy (default proxy):</string>
@@ -469,7 +469,7 @@
        <item>
         <widget class="QCheckBox" name="connectSocksTor">
          <property name="toolTip">
-          <string>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor onion services.</string>
+          <string>Connect to the Dogecoin network through a separate SOCKS5 proxy for Tor onion services.</string>
          </property>
          <property name="text">
           <string>Use separate SOCKS&amp;5 proxy to reach peers via Tor onion services:</string>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -73,7 +73,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</string>
+               <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Dogecoin network after a connection is established, but this process has not completed yet.</string>
               </property>
               <property name="text">
                <string/>
@@ -467,7 +467,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</string>
+               <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Dogecoin network after a connection is established, but this process has not completed yet.</string>
               </property>
               <property name="text">
                <string/>

--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -31,7 +31,7 @@
         <item row="6" column="0">
          <widget class="QLabel" name="label_3">
           <property name="toolTip">
-           <string>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</string>
+           <string>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Dogecoin network.</string>
           </property>
           <property name="text">
            <string>&amp;Message:</string>

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -54,7 +54,7 @@
       <item>
        <widget class="QValidatedLineEdit" name="payTo">
         <property name="toolTip">
-         <string>The Bitcoin address to send the payment to</string>
+         <string>The Dogecoin address to send the payment to</string>
         </property>
        </widget>
       </item>

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -48,7 +48,7 @@
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_SM">
            <property name="toolTip">
-            <string>The Bitcoin address to sign the message with</string>
+            <string>The Dogecoin address to sign the message with</string>
            </property>
           </widget>
          </item>
@@ -158,7 +158,7 @@
          <item>
           <widget class="QPushButton" name="signMessageButton_SM">
            <property name="toolTip">
-            <string>Sign the message to prove you own this Bitcoin address</string>
+            <string>Sign the message to prove you own this Dogecoin address</string>
            </property>
            <property name="text">
             <string>Sign &amp;Message</string>
@@ -264,7 +264,7 @@
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_VM">
            <property name="toolTip">
-            <string>The Bitcoin address the message was signed with</string>
+            <string>The Dogecoin address the message was signed with</string>
            </property>
           </widget>
          </item>
@@ -315,7 +315,7 @@
          <item>
           <widget class="QPushButton" name="verifyMessageButton_VM">
            <property name="toolTip">
-            <string>Verify the message to ensure it was signed with the specified Bitcoin address</string>
+            <string>Verify the message to ensure it was signed with the specified Dogecoin address</string>
            </property>
            <property name="text">
             <string>Verify &amp;Message</string>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -134,7 +134,7 @@ void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent) {
     // We don't want translators to use own addresses in translations
     // and this is the only place, where this address is supplied.
     widget->setPlaceholderText(
-        QObject::tr("Enter a Bitcoin address (e.g. %1)")
+        QObject::tr("Enter a Dogecoin address (e.g. %1)")
             .arg(QString::fromStdString(DummyAddress(Params()))));
     widget->setValidator(
         new BitcoinAddressEntryValidator(Params().CashAddrPrefix(), parent));

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -43,11 +43,11 @@
     </message>
     <message>
         <source>Choose the address to send coins to</source>
-        <translation>Wählen Sie die Adresse aus, an die Sie Bitcoins senden möchten</translation>
+        <translation>Wählen Sie die Adresse aus, an die Sie Dogecoins senden möchten</translation>
     </message>
     <message>
         <source>Choose the address to receive coins with</source>
-        <translation>Wählen Sie die Adresse aus, über die Sie Bitcoins empfangen wollen</translation>
+        <translation>Wählen Sie die Adresse aus, über die Sie Dogecoins empfangen wollen</translation>
     </message>
     <message>
         <source>C&amp;hoose</source>
@@ -62,12 +62,12 @@
         <translation>Empfangsadressen</translation>
     </message>
     <message>
-        <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation>Dies sind ihre Bitcoin-Adressen zum Tätigen von Überweisungen. Bitte prüfen Sie den Betrag und die Empfangsadresse, bevor Sie Bitcoins überweisen.</translation>
+        <source>These are your Dogecoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
+        <translation>Dies sind ihre Dogecoin-Adressen zum Tätigen von Überweisungen. Bitte prüfen Sie den Betrag und die Empfangsadresse, bevor Sie Dogecoins überweisen.</translation>
     </message>
     <message>
-        <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
-        <translation>Dies sind Ihre Bitcoin-Adressen zum Empfangen von Zahlungen. Es wird empfohlen, für jede Transaktion eine neue Empfangsadresse zu verwenden.</translation>
+        <source>These are your Dogecoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
+        <translation>Dies sind Ihre Dogecoin-Adressen zum Empfangen von Zahlungen. Es wird empfohlen, für jede Transaktion eine neue Empfangsadresse zu verwenden.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>
@@ -169,7 +169,7 @@
     </message>
     <message>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation>Warnung: Wenn Sie Ihre Wallet verschlüsseln und Ihre Passphrase verlieren, werden Sie &lt;b&gt;alle Ihre Bitcoins verlieren&lt;/b&gt;!</translation>
+        <translation>Warnung: Wenn Sie Ihre Wallet verschlüsseln und Ihre Passphrase verlieren, werden Sie &lt;b&gt;alle Ihre Dogecoins verlieren&lt;/b&gt;!</translation>
     </message>
     <message>
         <source>Are you sure you wish to encrypt your wallet?</source>
@@ -181,7 +181,7 @@
     </message>
     <message>
         <source>%1 will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation>%1 wird jetzt beendet, um den Verschlüsselungsprozess abzuschließen. Bitte beachten Sie, dass die Wallet-Verschlüsselung nicht vollständig vor Diebstahl Ihrer Bitcoins durch Schadprogramme schützt, die Ihren Computer befällt.</translation>
+        <translation>%1 wird jetzt beendet, um den Verschlüsselungsprozess abzuschließen. Bitte beachten Sie, dass die Wallet-Verschlüsselung nicht vollständig vor Diebstahl Ihrer Dogecoins durch Schadprogramme schützt, die Ihren Computer befällt.</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
@@ -338,8 +338,8 @@
         <translation>Reindiziere Blöcke auf Datenträger...</translation>
     </message>
     <message>
-        <source>Send coins to a Bitcoin address</source>
-        <translation>Bitcoins an eine Bitcoin-Adresse überweisen</translation>
+        <source>Send coins to a Dogecoin address</source>
+        <translation>Dogecoins an eine Dogecoin-Adresse überweisen</translation>
     </message>
     <message>
         <source>Backup wallet to another location</source>
@@ -390,12 +390,12 @@
         <translation>Verschlüsselt die zu Ihrer Wallet gehörenden privaten Schlüssel</translation>
     </message>
     <message>
-        <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation>Nachrichten signieren, um den Besitz Ihrer Bitcoin-Adressen zu beweisen</translation>
+        <source>Sign messages with your Dogecoin addresses to prove you own them</source>
+        <translation>Nachrichten signieren, um den Besitz Ihrer Dogecoin-Adressen zu beweisen</translation>
     </message>
     <message>
-        <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation>Nachrichten verifizieren, um sicherzustellen, dass diese mit den angegebenen Bitcoin-Adressen signiert wurden</translation>
+        <source>Verify messages to ensure they were signed with specified Dogecoin addresses</source>
+        <translation>Nachrichten verifizieren, um sicherzustellen, dass diese mit den angegebenen Dogecoin-Adressen signiert wurden</translation>
     </message>
     <message>
         <source>&amp;File</source>
@@ -742,8 +742,8 @@
         <translation>Zahlungsadresse bearbeiten</translation>
     </message>
     <message>
-        <source>The entered address "%1" is not a valid Bitcoin address.</source>
-        <translation>Die eingegebene Adresse "%1" ist keine gültige Bitcoin-Adresse.</translation>
+        <source>The entered address "%1" is not a valid Dogecoin address.</source>
+        <translation>Die eingegebene Adresse "%1" ist keine gültige Dogecoin-Adresse.</translation>
     </message>
     <message>
         <source>The entered address "%1" is already in the address book.</source>
@@ -891,7 +891,7 @@
     </message>
     <message>
         <source>Attempting to spend bitcoins that are affected by not-yet-displayed transactions will not be accepted by the network.</source>
-        <translation>Versuche, Bitcoins aus noch nicht angezeigten Transaktionen auszugeben, werden vom Netzwerk nicht akzeptiert.</translation>
+        <translation>Versuche, Dogecoins aus noch nicht angezeigten Transaktionen auszugeben, werden vom Netzwerk nicht akzeptiert.</translation>
     </message>
     <message>
         <source>Number of blocks left</source>
@@ -1145,7 +1145,7 @@
     </message>
     <message>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation>Wählen Sie die standardmäßige Untereinheit, die in der Benutzeroberfläche und beim Überweisen von Bitcoins angezeigt werden soll.</translation>
+        <translation>Wählen Sie die standardmäßige Untereinheit, die in der Benutzeroberfläche und beim Überweisen von Dogecoins angezeigt werden soll.</translation>
     </message>
     <message>
         <source>Whether to show coin control features or not.</source>
@@ -1286,8 +1286,8 @@
         <translation>Ungültige Zahlungsadresse %1</translation>
     </message>
     <message>
-        <source>URI cannot be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation>URI kann nicht analysiert werden! Dies kann durch eine ungültige Bitcoin-Adresse oder fehlerhafte URI-Parameter verursacht werden.</translation>
+        <source>URI cannot be parsed! This can be caused by an invalid Dogecoin address or malformed URI parameters.</source>
+        <translation>URI kann nicht analysiert werden! Dies kann durch eine ungültige Dogecoin-Adresse oder fehlerhafte URI-Parameter verursacht werden.</translation>
     </message>
     <message>
         <source>Payment request file handling</source>
@@ -1380,8 +1380,8 @@
         <translation>Betrag</translation>
     </message>
     <message>
-        <source>Enter a Bitcoin address (e.g. %1)</source>
-        <translation>Bitcoin-Adresse eingeben (z.B. %1)</translation>
+        <source>Enter a Dogecoin address (e.g. %1)</source>
+        <translation>Dogecoin-Adresse eingeben (z.B. %1)</translation>
     </message>
     <message>
         <source>%1 d</source>
@@ -1954,7 +1954,7 @@
     <name>SendCoinsDialog</name>
     <message>
         <source>Send Coins</source>
-        <translation>Bitcoins überweisen</translation>
+        <translation>Dogecoins überweisen</translation>
     </message>
     <message>
         <source>Coin Control Features</source>
@@ -2209,8 +2209,8 @@
         <translation><numerusform>Voraussichtlicher Beginn der Bestätigung innerhalb von %n Block.</numerusform><numerusform>Voraussichtlicher Beginn der Bestätigung innerhalb von %n Blöcken.</numerusform></translation>
     </message>
     <message>
-        <source>Warning: Invalid Bitcoin address</source>
-        <translation>Warnung: Ungültige Bitcoin-Adresse</translation>
+        <source>Warning: Invalid Dogecoin address</source>
+        <translation>Warnung: Ungültige Dogecoin-Adresse</translation>
     </message>
     <message>
         <source>Warning: Unknown change address</source>
@@ -2252,7 +2252,7 @@
         <translation>Dies ist eine normale Überweisung.</translation>
     </message>
     <message>
-        <source>The Bitcoin address to send the payment to</source>
+        <source>The Dogecoin address to send the payment to</source>
         <translation>Die Zahlungsadresse der Überweisung</translation>
     </message>
     <message>
@@ -2273,7 +2273,7 @@
     </message>
     <message>
         <source>The fee will be deducted from the amount being sent. The recipient will receive less bitcoins than you enter in the amount field. If multiple recipients are selected, the fee is split equally.</source>
-        <translation>Die Gebühr wird vom zu überweisenden Betrag abgezogen. Der Empfänger wird also weniger Bitcoins erhalten, als Sie im Betrags-Feld eingegeben haben. Falls mehrere Empfänger ausgewählt wurden, wird die Gebühr gleichmäßig verteilt.</translation>
+        <translation>Die Gebühr wird vom zu überweisenden Betrag abgezogen. Der Empfänger wird also weniger Dogecoins erhalten, als Sie im Betrags-Feld eingegeben haben. Falls mehrere Empfänger ausgewählt wurden, wird die Gebühr gleichmäßig verteilt.</translation>
     </message>
     <message>
         <source>S&amp;ubtract fee from amount</source>
@@ -2342,11 +2342,11 @@
     </message>
     <message>
         <source>You can sign messages/agreements with your addresses to prove you can receive bitcoins sent to them. Be careful not to sign anything vague or random, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation>Sie können Nachrichten/Vereinbarungen mit Hilfe Ihrer Adressen signieren, um zu beweisen, dass Sie Bitcoins empfangen können, die an diese Adressen überwiesen werden. Seien Sie vorsichtig und signieren Sie nichts Vages oder Willkürliches, um Ihre Indentität vor Phishingangriffen zu schützen. Signieren Sie nur vollständig-detaillierte Aussagen, mit denen Sie auch einverstanden sind.</translation>
+        <translation>Sie können Nachrichten/Vereinbarungen mit Hilfe Ihrer Adressen signieren, um zu beweisen, dass Sie Dogecoins empfangen können, die an diese Adressen überwiesen werden. Seien Sie vorsichtig und signieren Sie nichts Vages oder Willkürliches, um Ihre Indentität vor Phishingangriffen zu schützen. Signieren Sie nur vollständig-detaillierte Aussagen, mit denen Sie auch einverstanden sind.</translation>
     </message>
     <message>
-        <source>The Bitcoin address to sign the message with</source>
-        <translation>Die Bitcoin-Adresse mit der die Nachricht signiert wird</translation>
+        <source>The Dogecoin address to sign the message with</source>
+        <translation>Die Dogecoin-Adresse mit der die Nachricht signiert wird</translation>
     </message>
     <message>
         <source>Choose previously used address</source>
@@ -2377,8 +2377,8 @@
         <translation>Aktuelle Signatur in die Zwischenablage kopieren</translation>
     </message>
     <message>
-        <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation>Die Nachricht signieren, um den Besitz dieser Bitcoin-Adresse zu beweisen</translation>
+        <source>Sign the message to prove you own this Dogecoin address</source>
+        <translation>Die Nachricht signieren, um den Besitz dieser Dogecoin-Adresse zu beweisen</translation>
     </message>
     <message>
         <source>Sign &amp;Message</source>
@@ -2401,12 +2401,12 @@
         <translation>Geben Sie die Zahlungsadresse des Empfängers, Nachricht (achten Sie darauf Zeilenumbrüche, Leerzeichen, Tabulatoren usw. exakt zu kopieren) und Signatur unten ein, um die Nachricht zu verifizieren. Vorsicht, interpretieren Sie nicht mehr in die Signatur hinein, als in der signierten Nachricht selber enthalten ist, um nicht von einem Man-in-the-middle-Angriff hinters Licht geführt zu werden. Beachten Sie dass dies nur beweißt, dass die signierende Partei über diese Adresse Überweisungen empfangen kann.</translation>
     </message>
     <message>
-        <source>The Bitcoin address the message was signed with</source>
-        <translation>Die Bitcoin-Adresse mit der die Nachricht signiert wurde</translation>
+        <source>The Dogecoin address the message was signed with</source>
+        <translation>Die Dogecoin-Adresse mit der die Nachricht signiert wurde</translation>
     </message>
     <message>
-        <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation>Die Nachricht verifizieren, um sicherzustellen, dass diese mit der angegebenen Bitcoin-Adresse signiert wurde</translation>
+        <source>Verify the message to ensure it was signed with the specified Dogecoin address</source>
+        <translation>Die Nachricht verifizieren, um sicherzustellen, dass diese mit der angegebenen Dogecoin-Adresse signiert wurde</translation>
     </message>
     <message>
         <source>Verify &amp;Message</source>
@@ -2631,7 +2631,7 @@
     </message>
     <message>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to "not accepted" and it won't be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation>Erzeugte Bitcoins müssen %1 Blöcke lang reifen, bevor sie ausgegeben werden können. Als Sie diesen Block erzeugten, wurde er an das Netzwerk übertragen, um ihn der Blockkette hinzuzufügen. Falls dies fehlschlägt wird der Status in "nicht angenommen" geändert und Sie werden keine Bitcoins gutgeschrieben bekommen. Das kann gelegentlich passieren, wenn ein anderer Knoten einen Block fast zeitgleich erzeugt.</translation>
+        <translation>Erzeugte Dogecoins müssen %1 Blöcke lang reifen, bevor sie ausgegeben werden können. Als Sie diesen Block erzeugten, wurde er an das Netzwerk übertragen, um ihn der Blockkette hinzuzufügen. Falls dies fehlschlägt wird der Status in "nicht angenommen" geändert und Sie werden keine Dogecoins gutgeschrieben bekommen. Das kann gelegentlich passieren, wenn ein anderer Knoten einen Block fast zeitgleich erzeugt.</translation>
     </message>
     <message>
         <source>Debug information</source>
@@ -2957,7 +2957,7 @@
     <name>WalletModel</name>
     <message>
         <source>Send Coins</source>
-        <translation>Bitcoins überweisen</translation>
+        <translation>Dogecoins überweisen</translation>
     </message>
 </context>
 <context>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -367,7 +367,7 @@ bool PaymentServer::handleURI(const CChainParams &params, const QString &s) {
         Q_EMIT message(
             tr("URI handling"),
             tr("URI cannot be parsed! This can be caused by an invalid "
-               "Bitcoin address or malformed URI parameters."),
+               "Dogecoin address or malformed URI parameters."),
             CClientUIInterface::ICON_WARNING);
     }
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -915,7 +915,7 @@ void SendCoinsDialog::coinControlChangeEdited(const QString &text) {
         } else if (!IsValidDestination(dest)) {
             // Invalid address
             ui->labelCoinControlChangeLabel->setText(
-                tr("Warning: Invalid Bitcoin address"));
+                tr("Warning: Invalid Dogecoin address"));
         } else {
             // Valid address
             if (!model->wallet().isSpendable(dest)) {

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -98,7 +98,7 @@ void SendCoinsEntry::setModel(WalletModel *_model) {
         ui->messageTextLabel->setToolTip(
             tr("A message that was attached to the %1 URI which will be stored "
                "with the transaction for your reference. Note: This message "
-               "will not be sent over the Bitcoin network.")
+               "will not be sent over the Dogecoin network.")
                 .arg(QString::fromStdString(
                     _model->getChainParams().CashAddrPrefix())));
     }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -831,7 +831,7 @@ static RPCHelpMan decodepsbt() {
                                     {RPCResult::Type::STR, "type",
                                      "The type, eg 'pubkeyhash'"},
                                     {RPCResult::Type::STR, "address",
-                                     " Bitcoin address if there is one"},
+                                     " Dogecoin address if there is one"},
                                 }},
                            }},
                           {RPCResult::Type::OBJ_DYN,

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -150,7 +150,7 @@ CMutableTransaction ConstructTransaction(const CChainParams &params,
             CTxDestination destination = DecodeDestination(name_, params);
             if (!IsValidDestination(destination)) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
-                                   std::string("Invalid Bitcoin address: ") +
+                                   std::string("Invalid Dogecoin address: ") +
                                        name_);
             }
 

--- a/src/wallet/rpc/backup.cpp
+++ b/src/wallet/rpc/backup.cpp
@@ -287,7 +287,7 @@ RPCHelpMan importaddress() {
         "\"importdescriptors\" for descriptor wallets.\n",
         {
             {"address", RPCArg::Type::STR, RPCArg::Optional::NO,
-             "The Bitcoin address (or hex-encoded script)"},
+             "The Dogecoin address (or hex-encoded script)"},
             {"label", RPCArg::Type::STR, RPCArg::Default{""},
              "An optional label"},
             {"rescan", RPCArg::Type::BOOL, RPCArg::Default{true},
@@ -384,7 +384,7 @@ RPCHelpMan importaddress() {
                         true /* apply_label */, 1 /* timestamp */);
                 } else {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
-                                       "Invalid Bitcoin address or script");
+                                       "Invalid Dogecoin address or script");
                 }
             }
             if (fRescan) {
@@ -894,7 +894,7 @@ RPCHelpMan dumpprivkey() {
                 DecodeDestination(strAddress, wallet->GetChainParams());
             if (!IsValidDestination(dest)) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
-                                   "Invalid Bitcoin address");
+                                   "Invalid Dogecoin address");
             }
             auto keyid = GetKeyForDestination(spk_man, dest);
             if (keyid.IsNull()) {
@@ -1672,7 +1672,8 @@ static std::string GetRescanErrorMessage(const std::string &object,
         "key creation, and could contain transactions pertaining to the %s. As "
         "a result, transactions and coins using this %s may not appear in "
         "the wallet. This error could be caused by pruning or data corruption "
-        "(see dogecoind log for details) and could be dealt with by downloading "
+        "(see dogecoind log for details) and could be dealt with by "
+        "downloading "
         "and rescanning the relevant blocks (see -reindex and -rescan "
         "options).",
         object, objectTimestamp, blockTimestamp, TIMESTAMP_WINDOW, object,

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -108,10 +108,11 @@ static RPCHelpMan getnewaddress() {
              "given name."},
             // Deprecated in v0.30.4
             {"address_type", RPCArg::Type::STR, RPCArg::Optional::OMITTED,
-             "DEPRECATED: The Bitcoin address type to use. Only available for "
+             "DEPRECATED: The Dogecoin address type to use. Only available for "
              "compatibility with Bitcoin and will be removed in the future. "
              "The only valid value is \"legacy\". Note that this does not "
-             "change the output of this RPC; in order to get a Bitcoin address "
+             "change the output of this RPC; in order to get a Dogecoin "
+             "address "
              "the -usecashaddr option should be disabled."},
         },
         RPCResult{RPCResult::Type::STR, "address", "The new eCash address"},
@@ -163,7 +164,7 @@ static RPCHelpMan getnewaddress() {
 static RPCHelpMan getrawchangeaddress() {
     return RPCHelpMan{
         "getrawchangeaddress",
-        "Returns a new Bitcoin address, for receiving change.\n"
+        "Returns a new Dogecoin address, for receiving change.\n"
         "This is for use with raw transactions, NOT normal use.\n",
         {},
         RPCResult{RPCResult::Type::STR, "address", "The address"},
@@ -238,7 +239,7 @@ static RPCHelpMan setlabel() {
                                                     wallet->GetChainParams());
             if (!IsValidDestination(dest)) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
-                                   "Invalid Bitcoin address");
+                                   "Invalid Dogecoin address");
             }
 
             std::string label = LabelFromValue(request.params[1]);
@@ -264,7 +265,7 @@ void ParseRecipients(const UniValue &address_amounts,
         CTxDestination dest = DecodeDestination(address, chainParams);
         if (!IsValidDestination(dest)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
-                               std::string("Invalid Bitcoin address: ") +
+                               std::string("Invalid Dogecoin address: ") +
                                    address);
         }
 
@@ -506,7 +507,7 @@ static Amount GetReceived(const CWallet &wallet, const UniValue &params,
             DecodeDestination(params[0].get_str(), wallet.GetChainParams());
         if (!IsValidDestination(dest)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
-                               "Invalid Bitcoin address");
+                               "Invalid Dogecoin address");
         }
         CScript script_pub_key = GetScriptForDestination(dest);
         if (!wallet.IsMine(script_pub_key)) {
@@ -876,7 +877,7 @@ static RPCHelpMan addmultisigaddress() {
         "addmultisigaddress",
         "Add an nrequired-to-sign multisignature address to the wallet. "
         "Requires a new wallet backup.\n"
-        "Each key is a Bitcoin address or hex-encoded public key.\n"
+        "Each key is a Dogecoin address or hex-encoded public key.\n"
         "This functionality is only intended for use with non-watchonly "
         "addresses.\n"
         "See `importaddress` for watchonly p2sh address support.\n"
@@ -3138,7 +3139,7 @@ static RPCHelpMan listunspent() {
                     if (!IsValidDestination(dest)) {
                         throw JSONRPCError(
                             RPC_INVALID_ADDRESS_OR_KEY,
-                            std::string("Invalid Bitcoin address: ") +
+                            std::string("Invalid Dogecoin address: ") +
                                 input.get_str());
                     }
                     if (!destinations.insert(dest).second) {

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -185,7 +185,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         )
         assert_raises_rpc_error(
             -5,
-            "Invalid Bitcoin address",
+            "Invalid Dogecoin address",
             self.nodes[0].createrawtransaction,
             [],
             {"foo": 0},

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -464,16 +464,16 @@ class WalletTest(BitcoinTestFramework):
         )
 
         # This will raise an exception for attempting to get the private key of
-        # an invalid Bitcoin address
+        # an invalid Dogecoin address
         assert_raises_rpc_error(
-            -5, "Invalid Bitcoin address", self.nodes[0].dumpprivkey, "invalid"
+            -5, "Invalid Dogecoin address", self.nodes[0].dumpprivkey, "invalid"
         )
 
         # This will raise an exception for attempting to set a label for an
-        # invalid Bitcoin address
+        # invalid Dogecoin address
         assert_raises_rpc_error(
             -5,
-            "Invalid Bitcoin address",
+            "Invalid Dogecoin address",
             self.nodes[0].setlabel,
             "invalid address",
             "label",
@@ -482,7 +482,7 @@ class WalletTest(BitcoinTestFramework):
         # This will raise an exception for importing an invalid address
         assert_raises_rpc_error(
             -5,
-            "Invalid Bitcoin address or script",
+            "Invalid Dogecoin address or script",
             self.nodes[0].importaddress,
             "invalid",
         )


### PR DESCRIPTION
In many places, we still reference "Bitcoin" or "Bitcoin-abc". This is confusing to the user, so we fix it.

Translations are left unchanged, except the German one because I speak German and after the US, Germany has the most Dogecoin nodes.