### PR TITLE
[Dogecash] Fix "Illegal use of SIGHASH_FORKID" in wallet

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -269,7 +269,10 @@ std::vector<uint8_t> ParseHexUV(const UniValue &v, const std::string &strName) {
 }
 
 SigHashType ParseSighashString(const UniValue &sighash) {
-    SigHashType sigHashType = SigHashType().withForkId();
+    SigHashType sigHashType =
+        GetSignScriptFlags() & SCRIPT_ENABLE_SIGHASH_FORKID
+            ? SigHashType().withForkId()
+            : SigHashType();
     if (!sighash.isNull()) {
         static std::map<std::string, int> map_sighash_values = {
             {"ALL", SIGHASH_ALL},

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2017,7 +2017,11 @@ bool CWallet::SignTransaction(CMutableTransaction &tx) const {
                  wtx.IsCoinBase());
     }
     std::map<int, std::string> input_errors;
-    return SignTransaction(tx, coins, SigHashType().withForkId(), input_errors);
+    return SignTransaction(tx, coins,
+                           GetSignScriptFlags() & SCRIPT_ENABLE_SIGHASH_FORKID
+                               ? SigHashType()
+                               : SigHashType().withForkId(),
+                           input_errors);
 }
 
 bool CWallet::SignTransaction(CMutableTransaction &tx,


### PR DESCRIPTION
When the user provides no sighash, it defaulted to using `withForkId` when parsing the sighash. Now it toggles based on settings.