### PR TITLE
[Dogecash] Use Dogecoin's default fees

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -27,7 +27,7 @@ static constexpr uint64_t DEFAULT_MAX_GENERATED_BLOCK_SIZE{ONE_MEGABYTE - 1000};
  * Default for -blockmintxfee, which sets the minimum feerate for a transaction
  * in blocks created by mining code.
  */
-static constexpr Amount DEFAULT_BLOCK_MIN_TX_FEE_PER_KB(1000 * SATOSHI);
+static constexpr Amount DEFAULT_BLOCK_MIN_TX_FEE_PER_KB(COIN / 1000);
 /**
  * The maximum size for transactions we're willing to relay/mine.
  */
@@ -64,7 +64,7 @@ static constexpr bool DEFAULT_PERMIT_BAREMULTISIG{true};
 static constexpr Amount DUST_RELAY_TX_FEE(1000 * SATOSHI);
 
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
-static constexpr Amount DEFAULT_MIN_RELAY_TX_FEE_PER_KB(1000 * SATOSHI);
+static constexpr Amount DEFAULT_MIN_RELAY_TX_FEE_PER_KB(COIN / 1000);
 
 /**
  * When transactions fail script evaluations under standard flags, this flagset

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -80,7 +80,7 @@ MakeWalletDatabase(const std::string &name, const DatabaseOptions &options,
                    DatabaseStatus &status, bilingual_str &error);
 
 //! -paytxfee default
-constexpr Amount DEFAULT_PAY_TX_FEE = Amount::zero();
+constexpr Amount DEFAULT_PAY_TX_FEE = COIN / 100;
 //! -fallbackfee default
 static const Amount DEFAULT_FALLBACK_FEE = Amount::zero();
 //! -mintxfee default
@@ -105,9 +105,9 @@ static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 //! -maxtxfee default
-constexpr Amount DEFAULT_TRANSACTION_MAXFEE{COIN / 10};
+constexpr Amount DEFAULT_TRANSACTION_MAXFEE{100 * COIN};
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
-constexpr Amount HIGH_TX_FEE_PER_KB{COIN / 100};
+constexpr Amount HIGH_TX_FEE_PER_KB{10 * COIN};
 //! -maxtxfee will warn if called with a higher fee than this amount (in
 //! satoshis)
 constexpr Amount HIGH_MAX_TX_FEE{100 * HIGH_TX_FEE_PER_KB};

--- a/test/functional/dogecoin_default_fees.py
+++ b/test/functional/dogecoin_default_fees.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2024 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test default dogecoin fees.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, remove_from_config
+
+
+class DogecoinFeesTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-usedogeunit=1"]]
+        self.rpc_timeout = 240
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Remove test framework configs added in util.py
+        remove_from_config(
+            node.datadir, ["minrelaytxfee=10", "blockmintxfee=10", "fallbackfee=200"]
+        )
+
+        self.restart_node(0)
+
+        assert_equal(node.getnetworkinfo()["relayfee"], Decimal("0.001"))
+        assert_equal(node.getmempoolinfo()["minrelaytxfee"], Decimal("0.001"))
+        assert_equal(node.getmempoolinfo()["mempoolminfee"], Decimal("0.001"))
+
+        address = node.getnewaddress()
+        address2 = node.getnewaddress()
+
+        self.generatetoaddress(node, 110, address)
+
+        txid = node.sendtoaddress(address2, 10)
+
+        # -paytxfee is 10x that of the relay fee
+        tx = node.gettransaction(txid)
+        assert_equal(tx["fee"], Decimal("-0.0022500"))
+
+
+if __name__ == "__main__":
+    DogecoinFeesTest().main()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -46,6 +46,7 @@ class NotificationsTest(BitcoinTestFramework):
             [
                 f"-alertnotify=echo > {os.path.join(self.alertnotify_dir, '%s')}",
                 f"-blocknotify=echo > {os.path.join(self.blocknotify_dir, '%s')}",
+                "-paytxfee=10",
             ],
             [
                 "-rescan",
@@ -53,6 +54,7 @@ class NotificationsTest(BitcoinTestFramework):
                     "-walletnotify=echo >"
                     f" {os.path.join(self.walletnotify_dir, notify_outputname('%w', '%s'))}"
                 ),
+                "-paytxfee=10",
             ],
         ]
         self.wallet_names = [self.default_wallet_name, self.wallet]

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -34,6 +34,7 @@ class TestBitcoinCli(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
+        self.extra_args = [["-paytxfee=10"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_cli()

--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -27,7 +27,7 @@ from test_framework.p2p import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 
-MAX_FEE_FILTER = Decimal(9170997) / XEC
+MAX_FEE_FILTER = Decimal(9452957) / XEC
 NORMAL_FEE_FILTER = Decimal(100) / XEC
 
 

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -30,7 +30,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         # This test isn't testing tx relay. Set whitelist on the peers for
         # instant tx relay.
-        self.extra_args = [["-whitelist=noban@127.0.0.1"]] * self.num_nodes
+        self.extra_args = [
+            ["-whitelist=noban@127.0.0.1", "-maxtxfee=100000"]
+        ] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -23,6 +23,7 @@ class PSBTTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.supports_cli = False
+        self.extra_args = [["-maxtxfee=100000"]] * 3
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -481,6 +481,8 @@ def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=
         f.write("natpmp=0\n")
         f.write("usecashaddr=1\n")
         f.write("usedogeunit=0\n")
+        f.write("minrelaytxfee=10\n")
+        f.write("blockmintxfee=10\n")
         # Increase peertimeout to avoid disconnects while using mocktime.
         # peertimeout is measured in mock time, so setting it large enough to
         # cover any duration in mock time is sufficient. It can be overridden
@@ -496,10 +498,24 @@ def get_datadir_path(dirname, n):
     return os.path.join(dirname, f"node{str(n)}")
 
 
+def config_path(datadir):
+    return os.path.join(datadir, "dogecoin.conf")
+
+
 def append_config(datadir, options):
-    with open(os.path.join(datadir, "dogecoin.conf"), "a", encoding="utf8") as f:
+    with open(config_path(datadir), "a", encoding="utf8") as f:
         for option in options:
             f.write(f"{option}\n")
+
+
+def remove_from_config(datadir, options):
+    with open(config_path(datadir), "r", encoding="utf8") as f:
+        config = f.read()
+        for option in options:
+            config = config.replace(option + "\n", "")
+
+    with open(config_path(datadir), "w", encoding="utf8") as f:
+        f.write(config)
 
 
 def get_auth_cookie(datadir, chain):

--- a/test/functional/wallet_avoidreuse.py
+++ b/test/functional/wallet_avoidreuse.py
@@ -78,6 +78,7 @@ class AvoidReuseTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.noban_tx_relay = True
+        self.extra_args = [["-paytxfee=10"]] * 2
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -23,7 +23,7 @@ class WalletTest(BitcoinTestFramework):
         self.noban_tx_relay = True
         self.setup_clean_chain = True
         self.extra_args = [
-            ["-acceptnonstdtxn=1"],
+            ["-acceptnonstdtxn=1", "-paytxfee=10"],
         ] * self.num_nodes
         self.supports_cli = False
 

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -4,7 +4,7 @@
 
 from test_framework.blocktools import TIME_GENESIS_BLOCK
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.util import append_config, assert_equal, assert_raises_rpc_error
 
 
 class CreateTxWalletTest(BitcoinTestFramework):
@@ -20,6 +20,8 @@ class CreateTxWalletTest(BitcoinTestFramework):
         self.nodes[0].setmocktime(TIME_GENESIS_BLOCK)
         self.generate(self.nodes[0], 200)
         self.nodes[0].setmocktime(0)
+
+        append_config(self.nodes[0].datadir, ["maxtxfee=100000"])
 
         self.test_anti_fee_sniping_disabled()
         self.test_tx_size_too_large()

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -15,15 +15,15 @@ class WalletGroupTest(BitcoinTestFramework):
         self.num_nodes = 5
         self.noban_tx_relay = True
         self.extra_args = [
-            [],
-            [],
-            ["-avoidpartialspends"],
+            ["-paytxfee=10"],
+            ["-paytxfee=10"],
+            ["-avoidpartialspends", "-paytxfee=10"],
             # 2.93 XEC is the threshold that causes a node to prefer a
             # non-grouped tx (3 inputs, 2 outputs) to a grouped tx (5 inputs,
             # 2 outputs). The fee for the grouped tx is 294 sats higher than
             # the fee for the non-grouped tx. See tx5 below.
-            ["-maxapsfee=2.93"],
-            ["-maxapsfee=2.94"],
+            ["-maxapsfee=2.93", "-paytxfee=10"],
+            ["-maxapsfee=2.94", "-paytxfee=10"],
         ]
 
         self.rpc_timeout = 480

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -30,7 +30,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.noban_tx_relay = True
-        self.extra_args = [[], ["-keypool=5"]]
+        self.extra_args = [["-paytxfee=10"], ["-keypool=5", "-paytxfee=10"]]
         self.setup_clean_chain = True
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -358,11 +358,13 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_equal(batch[0]["result"]["chain"], self.chain)
         assert_equal(batch[1]["result"]["walletname"], "w1")
 
-        self.log.info("Check for per-wallet settxfee call")
-        assert_equal(w1.getwalletinfo()["paytxfee"], 0)
-        assert_equal(w2.getwalletinfo()["paytxfee"], 0)
+        self.log.info(
+            "Check for per-wallet settxfee call (paytxfee defaults to 10000 on Dogecoin)"
+        )
+        assert_equal(w1.getwalletinfo()["paytxfee"], 10000)
+        assert_equal(w2.getwalletinfo()["paytxfee"], 10000)
         w2.settxfee(1000)
-        assert_equal(w1.getwalletinfo()["paytxfee"], 0)
+        assert_equal(w1.getwalletinfo()["paytxfee"], 10000)
         assert_equal(w2.getwalletinfo()["paytxfee"], Decimal("1000.00"))
 
         self.log.info("Test dynamic wallet loading")


### PR DESCRIPTION
Dogecoin fees are significantly higher than on XEC.

These are the default settings:
- `relaymintxfee`: 0.001 DOGE/kB
- `blockmintxfee`: 0.001 DOGE/kB
- `paytxfee`: 0.01 DOGE/kB (which still seems to be below what's needed to get it mined)