### PR TITLE
[Dogecash] Fix `TRACK_SIZE_VERSION`, update version to 0.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE
 )
 
 project(dogecash
-	VERSION 0.1.0
+	VERSION 0.3.0
 	DESCRIPTION "Dogecash is a full node implementation of the Dogecoin protocol."
 	HOMEPAGE_URL "https://www.dogecash.io"
 )

--- a/src/chain.h
+++ b/src/chain.h
@@ -68,7 +68,7 @@ bool AreOnTheSameFork(const CBlockIndex *pa, const CBlockIndex *pb);
 /** Used to marshal pointers into hashes for db storage. */
 class CDiskBlockIndex : public CBlockIndex {
 public:
-    static constexpr int TRACK_SIZE_VERSION = 220800;
+    static constexpr int TRACK_SIZE_VERSION = 30000;
 
     BlockHash hashPrev;
 
@@ -89,7 +89,7 @@ public:
         READWRITE(obj.nStatus);
         READWRITE(VARINT(obj.nTx));
 
-        // The size of the blocks are tracked starting at version 0.22.8
+        // The size of the blocks are tracked starting at version 0.3.0
         if (obj.nStatus.hasData() && _nVersion >= TRACK_SIZE_VERSION) {
             READWRITE(VARINT(obj.nSize));
         }


### PR DESCRIPTION
Currently, we don't track the size of blocks in `CDiskBlockIndex`, because we didn't update the `TRACK_SIZE_VERSION`. This means people are prompted to upgrade their DB at every version bump.

This fix unfortunately requires everyone to -reindex their DB (which is unavoidable since the data isn't there), but at least this time they only have to do it once.